### PR TITLE
fix http 400 cased by different length in requestBody and requestBodyBytes

### DIFF
--- a/src/main/java/com/rosspaffett/mattercraft/MatterbridgeApiClient.java
+++ b/src/main/java/com/rosspaffett/mattercraft/MatterbridgeApiClient.java
@@ -45,7 +45,7 @@ public class MatterbridgeApiClient {
 
         try (OutputStream outputStream = connection.getOutputStream()) {
             byte[] requestBodyBytes = requestBody.getBytes(StandardCharsets.UTF_8);
-            outputStream.write(requestBodyBytes, 0, requestBody.length());
+            outputStream.write(requestBodyBytes, 0, requestBodyBytes.length);
         }
 
         if (connection.getResponseCode() >= 400) {


### PR DESCRIPTION
#1 
